### PR TITLE
REST Docs 샘플 작성

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,10 +109,69 @@
 
     <build>
         <plugins>
+
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+
+            <!-- Asciidoctor 플러그인 -->
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>generate-docs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html</backend>
+                            <doctype>book</doctype>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework.restdocs</groupId>
+                        <artifactId>spring-restdocs-asciidoctor</artifactId>
+                        <version>1.2.6.RELEASE</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+            <!-- Asciidoctor 패키징 -->
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.7</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>
+                                ${project.build.outputDirectory}/static/docs    <!-- 빌드된 jar 파일의 해당 디렉토리 하위에 index.html 파일 저장 -->
+                            </outputDirectory>
+                            <outputDirectory>
+                                ${project.basedir}/src/main/resources/static/docs   <!-- local 디렉토리에 index.html 파일 저장 -->
+                            </outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/generated-docs
+                                    </directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -1,0 +1,114 @@
+ifndef::snippets[]
+:snippets: ../../../target/generated-snippets
+endif::[]
+= UAD2 RESTful API 가이드
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+:operation-curl-request-title: Example request
+:operation-http-response-title: Example response
+
+[[overview]]
+== 개요
+
+UAD2 스프링 API 서버
+
+[[overview-domain]]
+=== 도메인
+
+|===
+| 환경 | 도메인
+
+| 운영
+| `https://pjhdev.com`
+|===
+
+[[overview-http-verbs]]
+=== HTTP 메소드
+
+|===
+| 메소드 | 설명
+
+| `GET`
+| 리소스 검색
+
+| `POST`
+| 리소스 생성
+
+| `PATCH`
+| 리소스 부분 수정
+
+| `DELETE`
+| 리소스 삭제
+|===
+
+[[overview-http-status-codes]]
+=== HTTP 응답 코드
+
+|===
+| 응답 코드 | 설명
+
+| `200 OK`
+| 요청 성공적으로 수행.
+
+| `201 Created`
+| 리소스 생성 완료.
+
+| `204 No Content`
+| 기존 리소스 수정 완료.
+
+| `400 Bad Request`
+| 잘못된 요청.
+
+| `404 Not Found`
+| 요청한 리소스 존재하지 않음.
+|===
+
+[[API]]
+== API
+
+[[getAll]]
+=== 멤버 전체 조회
+
+==== Request HTTP
+include::{snippets}/sample/getAll/http-request.adoc[]
+
+==== Response
+include::{snippets}/sample/getAll/response-fields.adoc[]
+
+==== Response paging link
+include::{snippets}/sample/getAll/links.adoc[]
+
+[[getMember]]
+=== 멤버 개별 조회
+
+==== Request HTTP
+include::{snippets}/sample/getMember/http-request.adoc[]
+
+==== Request path parameters
+include::{snippets}/sample/getMember/path-parameters.adoc[]
+
+==== Response Body
+include::{snippets}/sample/getMember/response-body.adoc[]
+
+==== Response
+include::{snippets}/sample/getMember/response-fields.adoc[]
+
+[[createMember]]
+=== 멤버 생성
+
+==== Request HTTP
+include::{snippets}/sample/createMember/http-request.adoc[]
+
+==== Request
+include::{snippets}/sample/createMember/request-fields.adoc[]
+
+==== Response Body
+include::{snippets}/sample/createMember/response-body.adoc[]
+
+==== Response
+include::{snippets}/sample/createMember/response-fields.adoc[]
+

--- a/src/test/java/com/uad2/application/ApplicationTests.java
+++ b/src/test/java/com/uad2/application/ApplicationTests.java
@@ -7,71 +7,139 @@ import com.uad2.application.member.entity.Member;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.uad2.application.api.document.utils.DocumentFormatGenerator.getDateFormat;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
-//@WebMvcTest//웹과 관련된 빈만 등록
+@AutoConfigureRestDocs(outputDir = "target/generated-snippets/sample")
+// @WebMvcTest   //웹과 관련된 빈만 등록
 public class ApplicationTests {
-    @Autowired
-    MockMvc mockMvc;//웹서버를 띄우진 않지만 디스패처서블릿을 사용
 
-    //mappingJackson이 있으면 자동 등록
+    @Autowired
+    MockMvc mockMvc;    // 웹서버를 띄우진 않지만 디스패처서블릿을 사용
+
+    // mappingJackson이 있으면 자동 등록
     @Autowired
     ObjectMapper objectMapper;
 
     @Test
     @TestDescription("전체 회원 조회")
-    public void getAllMembers() throws Exception{
-        mockMvc.perform(get("/api/member")
-        ).andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("_embedded.memberList[0]").exists());
+    public void getAllMembers() throws Exception {
+        // request
+        ResultActions result = mockMvc.perform(
+                get("/api/member")
+        );
+
+        // result
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("_embedded.memberList[0]").exists())
+                .andDo(document("getAll",
+                        preprocessResponse(prettyPrint()),
+                        links(  // _links path 하위
+                                linkWithRel("first").description("첫 페이지"),
+                                linkWithRel("self").description("현재 페이지"),
+                                linkWithRel("last").description("이전 페이지"),
+                                linkWithRel("next").description("다음 페이지")
+                        ),
+                        responseFields(
+                                subsectionWithPath("_embedded.memberList").description("전체 회원 데이터 리스트"),
+                                subsectionWithPath("_links").description("페이징 링크"),
+                                subsectionWithPath("page").description("페이징 관련 데이터")
+                        )
+                ));
     }
 
     @Test
     @TestDescription("개별 회원 조회")
-    public void getMember() throws Exception{
+    public void getMember() throws Exception {
+        // request
+        ResultActions result = mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/api/member/{name}", "testName")
+        );
 
-
-        mockMvc.perform(get("/api/member/{name}","유정현")
-        ).andDo(print())
-                .andExpect(status().isOk());
-                //.andExpect(jsonPath("_embedded.memberList[0]").exists());
+        // result
+        result.andExpect(status().isOk())
+                .andDo(document("getMember",
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("name").description("이름")
+                        ),
+                        responseFields(
+                                getResponseFileds()
+                                        .stream()
+                                        .map(FieldDescriptor::optional) // response body 필수값 여부 우선 optional 처리
+                                        .collect(Collectors.toList())
+                        )
+                ));
     }
 
     @Test
     @TestDescription("정상 실행")
-    public void createMember() throws Exception{
+    public void createMember() throws Exception {
         MemberDto member = MemberDto.builder()
                 .id("testId")
                 .pwd("testPwd").build();
-        mockMvc.perform(post("/api/member")
+
+        // request
+        ResultActions result = mockMvc.perform(post("/api/member")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaTypes.HAL_JSON)
                 .content(objectMapper.writeValueAsString(member))
-        ).andDo(print())
+        );
+
+        // result
+        result.andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("seq").exists())
                 .andExpect(header().exists(HttpHeaders.LOCATION))
-                .andExpect(header().string(HttpHeaders.CONTENT_TYPE,MediaTypes.HAL_JSON_UTF8_VALUE));
-
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, MediaTypes.HAL_JSON_UTF8_VALUE))
+                .andDo(document("createMember",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("id").type(JsonFieldType.STRING).description("계정 아이디"),
+                                fieldWithPath("pwd").type(JsonFieldType.STRING).description("계정 패스워드")
+                        ),
+                        responseFields(
+                                getResponseFileds()
+                                        .stream()
+                                        .map(FieldDescriptor::optional) // response body 필수값 여부 우선 optional 처리
+                                        .collect(Collectors.toList())
+                        )
+                ));
     }
 
     @Test
-    public void createMember_badRequest() throws Exception{
+    public void createMember_badRequest() throws Exception {
         Member member = Member.builder()
                 .id("testId")
                 .pwd("testPwd")
@@ -80,14 +148,13 @@ public class ApplicationTests {
         mockMvc.perform(post("/api/member")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .accept(MediaTypes.HAL_JSON)
-                .content(objectMapper.writeValueAsString(member))
-        ).andDo(print())
+                .content(objectMapper.writeValueAsString(member)))
+                .andDo(print())
                 .andExpect(status().isBadRequest());
     }
 
-
     @Test
-    public void createMember_badRequest_emptyInput() throws Exception{
+    public void createMember_badRequest_emptyInput() throws Exception {
         MemberDto memberDto = MemberDto.builder().build();
 
         mockMvc.perform(post("/api/member")
@@ -96,15 +163,38 @@ public class ApplicationTests {
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }
+
     @Test
-    public void createMember_badRequest_wrongInput() throws Exception{
+    public void createMember_badRequest_wrongInput() throws Exception {
         MemberDto memberDto = MemberDto.builder().build();
 
         mockMvc.perform(post("/api/member")
-                        .contentType(MediaType.APPLICATION_JSON_UTF8)
-                        .content(objectMapper.writeValueAsBytes(memberDto))
+                .contentType(MediaType.APPLICATION_JSON_UTF8)
+                .content(objectMapper.writeValueAsBytes(memberDto))
         ).andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$[0].objectName").exists());
     }
+
+    private List<FieldDescriptor> getResponseFileds() {
+        return Arrays.asList(
+                fieldWithPath("seq").type(JsonFieldType.NUMBER).description("테이블 인덱스"),
+                fieldWithPath("id").type(JsonFieldType.STRING).description("계정 아이디"),
+                fieldWithPath("pwd").type(JsonFieldType.STRING).description("계정 패스워드"),
+                fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
+                fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("핸드폰 번호"),
+                fieldWithPath("studentId").type(JsonFieldType.NUMBER).description("학번"),
+                fieldWithPath("birthDay").type(JsonFieldType.STRING).description("생년월일").attributes(getDateFormat()),
+                fieldWithPath("attdCnt").type(JsonFieldType.NUMBER).description("참석 횟수"),
+                fieldWithPath("profileImg").type(JsonFieldType.STRING).description("프로필 이미지").optional(),
+                fieldWithPath("sessionId").type(JsonFieldType.STRING).description("세션 고유번호").optional(),
+                fieldWithPath("sessionLimit").type(JsonFieldType.STRING).description("세션 만료시점").optional().attributes(getDateFormat()),
+                fieldWithPath("createdAt").type(JsonFieldType.STRING).description("계정 생성일").attributes(getDateFormat()),
+                fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("계정 수정일").attributes(getDateFormat()),
+                fieldWithPath("admin").type(JsonFieldType.BOOLEAN).description("관리자 여부"),
+                fieldWithPath("worker").type(JsonFieldType.BOOLEAN).description("직장인 여부"),
+                fieldWithPath("benefit").type(JsonFieldType.BOOLEAN).description("")
+        );
+    }
+
 }

--- a/src/test/java/com/uad2/application/api/document/utils/DocumentFormatGenerator.java
+++ b/src/test/java/com/uad2/application/api/document/utils/DocumentFormatGenerator.java
@@ -1,0 +1,17 @@
+package com.uad2.application.api.document.utils;
+
+import org.springframework.restdocs.snippet.Attributes;
+
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+/*
+ * @USER Jongyeob
+ * @DATE 2019-09-10
+ */
+public interface DocumentFormatGenerator {
+
+    static Attributes.Attribute getDateFormat() {
+        return key("format").value("yyyy-MM-dd hh:mm:ss");
+    }
+
+}

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
@@ -1,0 +1,14 @@
+===== End Point
+{{path}}
+
+[cols="5,5"]
+===== Path Parameters
+|===
+|파라미터|설명
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/parameters}}
+
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
@@ -1,0 +1,13 @@
+[cols="4,4,4,5"]
+
+|===
+|필드명|타입|필수값|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
@@ -1,0 +1,14 @@
+[cols="5,3,3,5,5"]
+
+|===
+|필드명|타입|필수값|양식|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#format}}{{.}}{{/format}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+
+|===


### PR DESCRIPTION
#### why
>- REST Docs 활용하여 API 명세서 작성.

#### what
>- API 명세서 작성하기 위해 Asciidoctor 플러그인을 추가하였다.
>- 멤버 API에 대한 테스트코드 기반으로 API 명세서를 작성하였다.
>- 메이븐 패키징 시, 자동으로 작성된 API 명세서가 '/static/docs' 하위에 저장된다.