### PR TITLE
Member dto 구조 변경

### DIFF
--- a/src/main/java/com/uad2/application/member/MemberValidator.java
+++ b/src/main/java/com/uad2/application/member/MemberValidator.java
@@ -4,14 +4,14 @@ package com.uad2.application.member;
  * @DATE 2019-09-09
  */
 
-import com.uad2.application.member.entity.MemberInsertDto;
+import com.uad2.application.member.dto.MemberDto;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 
 @Component
 public class MemberValidator {
-    public void createMemberValidate(MemberInsertDto memberInsertDto, Errors errors){
-        String id = memberInsertDto.getId();
+    public void createMemberValidate(MemberDto.Request request, Errors errors){
+        String id = request.getId();
         if(id == null || "".equals(id)){
             
             errors.rejectValue("id","wrongValue", "id is empty");

--- a/src/main/java/com/uad2/application/member/MemberValidator.java
+++ b/src/main/java/com/uad2/application/member/MemberValidator.java
@@ -10,8 +10,8 @@ import org.springframework.validation.Errors;
 
 @Component
 public class MemberValidator {
-    public void createMemberValidate(MemberDto.Request request, Errors errors){
-        String id = request.getId();
+    public void createMemberValidate(MemberDto.Request requestMember, Errors errors){
+        String id = requestMember.getId();
         if(id == null || "".equals(id)){
             
             errors.rejectValue("id","wrongValue", "id is empty");

--- a/src/main/java/com/uad2/application/member/controller/MemberController.java
+++ b/src/main/java/com/uad2/application/member/controller/MemberController.java
@@ -57,14 +57,14 @@ public class MemberController {
      * 회원 생성 API
      */
     @PostMapping(value = "/api/member", produces = MediaTypes.HAL_JSON_UTF8_VALUE)
-    public ResponseEntity createMember(@RequestBody MemberDto.Request request, Errors errors) throws Exception {
-        memberValidator.createMemberValidate(request, errors);
+    public ResponseEntity createMember(@RequestBody MemberDto.Request requestMember, Errors errors) throws Exception {
+        memberValidator.createMemberValidate(requestMember, errors);
         if (errors.hasErrors()) {
             return ResponseEntity.badRequest().body(errors);
         }
-        Member savedMember = memberService.createMember(request);
+        Member savedMember = memberService.createMember(requestMember);
         if (savedMember != null) {
-            URI createdUri = linkTo(MemberController.class).slash("id").slash(request.getId()).toUri();
+            URI createdUri = linkTo(MemberController.class).slash("id").slash(requestMember.getId()).toUri();
             return ResponseEntity.created(createdUri).body(MemberResponseUtil.makeResponseResource(modelMapper.map(savedMember, Member.class)));
         } else {
             return ResponseEntity.status(202).build();

--- a/src/main/java/com/uad2/application/member/controller/MemberController.java
+++ b/src/main/java/com/uad2/application/member/controller/MemberController.java
@@ -1,8 +1,8 @@
 package com.uad2.application.member.controller;
 
 import com.uad2.application.member.MemberValidator;
+import com.uad2.application.member.dto.MemberDto;
 import com.uad2.application.member.entity.Member;
-import com.uad2.application.member.entity.MemberInsertDto;
 import com.uad2.application.member.repository.MemberRepository;
 import com.uad2.application.member.service.MemberService;
 import com.uad2.application.utils.MemberResponseUtil;
@@ -29,35 +29,44 @@ public class MemberController {
     @Autowired
     private MemberRepository memberRepository;
 
-
     @Autowired
     MemberValidator memberValidator;
 
     @Autowired
     MemberService memberService;
 
+    /**
+     * 회원 전체 조회 API
+     */
     @GetMapping(value = "/api/member", produces = MediaTypes.HAL_JSON_UTF8_VALUE)
-    public ResponseEntity getAllMember(){
+    public ResponseEntity getAllMember() {
         List<Member> memberList = memberRepository.findAll();
         return ResponseEntity.ok(MemberResponseUtil.makeListResponseResource(memberList));
     }
+
+    /**
+     * 회원 id 조회 API
+     */
     @GetMapping(value = "/api/member/id/{id}", produces = MediaTypes.HAL_JSON_UTF8_VALUE)
-    public ResponseEntity getMemberById(@PathVariable String id){
+    public ResponseEntity getMemberById(@PathVariable String id) {
         Member member = memberRepository.findById(id);
         return ResponseEntity.ok(MemberResponseUtil.makeResponseResource(member));
     }
+
+    /**
+     * 회원 생성 API
+     */
     @PostMapping(value = "/api/member", produces = MediaTypes.HAL_JSON_UTF8_VALUE)
-    public ResponseEntity createMember(@RequestBody MemberInsertDto memberInsertDto, Errors errors) throws Exception{
-        memberValidator.createMemberValidate(memberInsertDto,errors);
-        if(errors.hasErrors()){
+    public ResponseEntity createMember(@RequestBody MemberDto.Request request, Errors errors) throws Exception {
+        memberValidator.createMemberValidate(request, errors);
+        if (errors.hasErrors()) {
             return ResponseEntity.badRequest().body(errors);
         }
-        Member savedMember = memberService.createMember(memberInsertDto);
-        if(savedMember != null){
-            URI createdUri = linkTo(MemberController.class).slash("id").slash(memberInsertDto.getId()).toUri();
+        Member savedMember = memberService.createMember(request);
+        if (savedMember != null) {
+            URI createdUri = linkTo(MemberController.class).slash("id").slash(request.getId()).toUri();
             return ResponseEntity.created(createdUri).body(MemberResponseUtil.makeResponseResource(modelMapper.map(savedMember, Member.class)));
-        }
-        else{
+        } else {
             return ResponseEntity.status(202).build();
         }
     }

--- a/src/main/java/com/uad2/application/member/dto/MemberDto.java
+++ b/src/main/java/com/uad2/application/member/dto/MemberDto.java
@@ -1,0 +1,64 @@
+package com.uad2.application.member.dto;
+
+/*
+ * @USER Jongyeob
+ * @DATE 2019-09-19
+ * @DESCRIPTION 회원 도메인에 대한 request, response 처리하는 커맨드 객체
+ */
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+
+public class MemberDto {
+
+    @Getter
+    @Setter
+    public static class Request {   // 프로퍼티 공통 사용여부에 따라 Create, Update로 분리해도 괜찮을 것 같다.
+        private String id;
+
+        private String pwd;
+
+        private String name;
+
+        private Date birthDay;
+
+        private int studentId;
+
+        private int isWorker;
+
+        private String phoneNumber;
+    }
+
+    @Getter
+    @Setter
+    public static class Response {
+        private String id;
+
+        private String name;
+
+        private int seq;
+
+        private String profileImg;
+
+        private int attdCnt;
+
+        private Date birthDay;
+
+        private int studentId;
+
+        private int isWorker;
+
+        private String phoneNumber;
+
+        private String sessionId;
+
+        private Date sessionLimit;
+
+        private int isAdmin;
+
+        private int isBenefit;
+    }
+
+}

--- a/src/main/java/com/uad2/application/member/dto/MemberDto.java
+++ b/src/main/java/com/uad2/application/member/dto/MemberDto.java
@@ -32,7 +32,6 @@ public class MemberDto {
     }
 
     @Getter
-    @Setter
     public static class Response {
         private String id;
 

--- a/src/main/java/com/uad2/application/member/resource/MemberExternalResource.java
+++ b/src/main/java/com/uad2/application/member/resource/MemberExternalResource.java
@@ -21,7 +21,7 @@ public class MemberExternalResource extends ResourceSupport {//.add로 링크추
      * @param response 회원 Response 커맨드 객체
      * @return MemberExternalResource 인스턴스를 반환한다.
      */
-    public static MemberExternalResource from(MemberDto.Response response) {
+    public static MemberExternalResource createResourceFrom(MemberDto.Response response) {
         return new MemberExternalResource(response);
     }
 

--- a/src/main/java/com/uad2/application/member/resource/MemberExternalResource.java
+++ b/src/main/java/com/uad2/application/member/resource/MemberExternalResource.java
@@ -5,17 +5,27 @@ package com.uad2.application.member.resource;
  * @DESCRIPTION api 반환용 회원 HAL 포멧
  */
 
-import com.uad2.application.member.entity.MemberExternalDto;
+import com.uad2.application.member.dto.MemberDto;
 import org.springframework.hateoas.ResourceSupport;
 
 public class MemberExternalResource extends ResourceSupport {//.add로 링크추가 가능
-    private MemberExternalDto memberExternalDto;
+    private MemberDto.Response response;
 
-    public MemberExternalResource(MemberExternalDto memberExternalDto){
-        this.memberExternalDto = memberExternalDto;
+    private MemberExternalResource(MemberDto.Response response) {
+        this.response = response;
     }
 
-    public MemberExternalDto getMember() {
-        return memberExternalDto;
+    /**
+     * 인스턴스 생성을 위한 정적 팩토리 메서드
+     *
+     * @param response 회원 Response 커맨드 객체
+     * @return MemberExternalResource 인스턴스를 반환한다.
+     */
+    public static MemberExternalResource from(MemberDto.Response response) {
+        return new MemberExternalResource(response);
+    }
+
+    public MemberDto.Response getMember() {
+        return response;
     }//return되는 필드명
 }

--- a/src/main/java/com/uad2/application/member/resource/MemberListExternalResource.java
+++ b/src/main/java/com/uad2/application/member/resource/MemberListExternalResource.java
@@ -5,19 +5,29 @@ package com.uad2.application.member.resource;
  * @DESCRIPTION api 반환용 회원 리스트 HAL 포멧
  */
 
-import com.uad2.application.member.entity.MemberExternalDto;
+import com.uad2.application.member.dto.MemberDto;
 import org.springframework.hateoas.ResourceSupport;
 
 import java.util.List;
 
 public class MemberListExternalResource extends ResourceSupport {
-    private List<MemberExternalDto> memberExternalDtoList;
+    private List<MemberDto.Response> responseList;
 
-    public MemberListExternalResource(List<MemberExternalDto> memberExternalDtoList){
-        this.memberExternalDtoList = memberExternalDtoList;
+    private MemberListExternalResource(List<MemberDto.Response> responseList) {
+        this.responseList = responseList;
     }
 
-    public List<MemberExternalDto> getMemberList() {
-        return memberExternalDtoList;
+    /**
+     * 인스턴스 생성을 위한 정적 팩토리 메서드
+     *
+     * @param responseList 회원 Response List 커맨드 객체
+     * @return MemberListExternalResource 인스턴스를 반환한다.
+     */
+    public static MemberListExternalResource from(List<MemberDto.Response> responseList) {
+        return new MemberListExternalResource(responseList);
+    }
+
+    public List<MemberDto.Response> getMemberList() {
+        return responseList;
     }
 }

--- a/src/main/java/com/uad2/application/member/resource/MemberListExternalResource.java
+++ b/src/main/java/com/uad2/application/member/resource/MemberListExternalResource.java
@@ -23,7 +23,7 @@ public class MemberListExternalResource extends ResourceSupport {
      * @param responseList 회원 Response List 커맨드 객체
      * @return MemberListExternalResource 인스턴스를 반환한다.
      */
-    public static MemberListExternalResource from(List<MemberDto.Response> responseList) {
+    public static MemberListExternalResource createResourceFrom(List<MemberDto.Response> responseList) {
         return new MemberListExternalResource(responseList);
     }
 

--- a/src/main/java/com/uad2/application/member/service/MemberService.java
+++ b/src/main/java/com/uad2/application/member/service/MemberService.java
@@ -19,11 +19,11 @@ public class MemberService {
     @Autowired
     private ModelMapper modelMapper;
 
-    public Member createMember(MemberDto.Request request) {
-        String phoneNumber = request.getPhoneNumber();
+    public Member createMember(MemberDto.Request requestMember) {
+        String phoneNumber = requestMember.getPhoneNumber();
         Member member = memberRepository.findByPhoneNumber(phoneNumber);
         if (member == null) {
-            return memberRepository.save(modelMapper.map(request, Member.class));
+            return memberRepository.save(modelMapper.map(requestMember, Member.class));
         } else {
             return null;
         }

--- a/src/main/java/com/uad2/application/member/service/MemberService.java
+++ b/src/main/java/com/uad2/application/member/service/MemberService.java
@@ -1,19 +1,11 @@
 package com.uad2.application.member.service;
 
-import com.uad2.application.member.controller.MemberController;
+import com.uad2.application.member.dto.MemberDto;
 import com.uad2.application.member.entity.Member;
-import com.uad2.application.member.entity.MemberInsertDto;
 import com.uad2.application.member.repository.MemberRepository;
-import com.uad2.application.utils.MemberResponseUtil;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-
-import javax.xml.ws.Response;
-import java.net.URI;
-
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 
 /*
  * @USER JungHyun
@@ -26,13 +18,13 @@ public class MemberService {
 
     @Autowired
     private ModelMapper modelMapper;
-    public Member createMember(MemberInsertDto memberInsertDto){
-        String phoneNumber = memberInsertDto.getPhoneNumber();
+
+    public Member createMember(MemberDto.Request request) {
+        String phoneNumber = request.getPhoneNumber();
         Member member = memberRepository.findByPhoneNumber(phoneNumber);
-        if(member == null){
-            return memberRepository.save(modelMapper.map(memberInsertDto,Member.class));
-        }
-        else{
+        if (member == null) {
+            return memberRepository.save(modelMapper.map(request, Member.class));
+        } else {
             return null;
         }
     }

--- a/src/main/java/com/uad2/application/utils/MemberResponseUtil.java
+++ b/src/main/java/com/uad2/application/utils/MemberResponseUtil.java
@@ -27,7 +27,7 @@ public class MemberResponseUtil {
      */
     public static MemberExternalResource makeResponseResource(Member member) {
         MemberDto.Response response = modelMapper.map(member, MemberDto.Response.class);
-        MemberExternalResource memberExternalResource = MemberExternalResource.from(response);
+        MemberExternalResource memberExternalResource = MemberExternalResource.createResourceFrom(response);
         memberExternalResource.add(new Link("/docs/index.html").withRel("profile"));
         return memberExternalResource;
     }
@@ -42,7 +42,7 @@ public class MemberResponseUtil {
         List<MemberDto.Response> responseList = memberList.stream()
                 .map(member -> modelMapper.map(member, MemberDto.Response.class))
                 .collect(Collectors.toList());
-        MemberListExternalResource memberListExternalResource = MemberListExternalResource.from(responseList);
+        MemberListExternalResource memberListExternalResource = MemberListExternalResource.createResourceFrom(responseList);
         memberListExternalResource.add(new Link("/docs/index.html").withRel("profile"));
         return memberListExternalResource;
     }

--- a/src/main/java/com/uad2/application/utils/MemberResponseUtil.java
+++ b/src/main/java/com/uad2/application/utils/MemberResponseUtil.java
@@ -5,15 +5,15 @@ package com.uad2.application.utils;
  * @DESCRIPTION 회원 API 반환 유틸
  */
 
-import com.uad2.application.member.resource.MemberExternalResource;
-import com.uad2.application.member.entity.MemberExternalDto;
+import com.uad2.application.member.dto.MemberDto;
 import com.uad2.application.member.entity.Member;
+import com.uad2.application.member.resource.MemberExternalResource;
 import com.uad2.application.member.resource.MemberListExternalResource;
 import org.modelmapper.ModelMapper;
 import org.springframework.hateoas.Link;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class MemberResponseUtil {
 
@@ -25,10 +25,10 @@ public class MemberResponseUtil {
      * @DESCRIPTION 회원 반환 resource 적용
      * @RESOURCE : HAL(반환 데이터에 관련 하이퍼링크를 제공하는 방식)을 적용한 반환 형식
      */
-    public static MemberExternalResource makeResponseResource(Member member){
-        MemberExternalDto memberExternalDto = modelMapper.map(member,MemberExternalDto.class);
-        MemberExternalResource memberExternalResource = new MemberExternalResource(memberExternalDto);
-        memberExternalResource.add(new Link("/docs/index.html") .withRel("profile"));
+    public static MemberExternalResource makeResponseResource(Member member) {
+        MemberDto.Response response = modelMapper.map(member, MemberDto.Response.class);
+        MemberExternalResource memberExternalResource = MemberExternalResource.from(response);
+        memberExternalResource.add(new Link("/docs/index.html").withRel("profile"));
         return memberExternalResource;
     }
 
@@ -38,13 +38,12 @@ public class MemberResponseUtil {
      * @DESCRIPTION 회원 리스트 반환 resource 적용
      * @RESOURCE : HAL(반환 데이터에 관련 하이퍼링크를 제공하는 방식)을 적용한 반환 형식
      */
-    public static MemberListExternalResource makeListResponseResource(List<Member> memberList){
-        List<MemberExternalDto> memberExternalDtoList = new ArrayList<>();
-        for (Member member : memberList) {
-            memberExternalDtoList.add(modelMapper.map(member,MemberExternalDto.class));
-        }
-        MemberListExternalResource memberListExternalResource = new MemberListExternalResource(memberExternalDtoList);
-        memberListExternalResource.add(new Link("/docs/index.html") .withRel("profile"));
+    public static MemberListExternalResource makeListResponseResource(List<Member> memberList) {
+        List<MemberDto.Response> responseList = memberList.stream()
+                .map(member -> modelMapper.map(member, MemberDto.Response.class))
+                .collect(Collectors.toList());
+        MemberListExternalResource memberListExternalResource = MemberListExternalResource.from(responseList);
+        memberListExternalResource.add(new Link("/docs/index.html").withRel("profile"));
         return memberListExternalResource;
     }
 }


### PR DESCRIPTION
#### why
>- Member request, response처리를 위한 dto 구조 변경.

#### what
>- 분리되어 있던 ExternalDto, InsertDto를 MemberDto에 이너 클래스로 통합.
>- Member API에 대해 반복적으로 사용되는 동일한 목적의 커맨드 객체이기에, 하나의 객체에서 관리하는 것이 효율적이라고 판단.
>- ExternalResource 객체 생성 책임을 클래스 본인에게 부여. (정적 팩토리 메서드 패턴 활용해봄. 피드백 부탁함)
