### PR TITLE
[member-비밀번호 체크 추가, ExceptionAdvice 에 공통 폼 메소드 추가(2)

### DIFF
--- a/src/main/java/com/uad2/application/exception/ExceptionAdvice.java
+++ b/src/main/java/com/uad2/application/exception/ExceptionAdvice.java
@@ -14,22 +14,41 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestControllerAdvice
-public class ExceptionAdvice {
-    @ExceptionHandler(value = { RuntimeException.class })
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    public Map<String,String> runtimeException(RuntimeException e) {
+public class ExceptionAdvice{
+    private Map<String,String> getErrorForm(RuntimeException e) {
         Map<String,String> returnMap = new HashMap<>();
         returnMap.put("error",e.toString());
         returnMap.put("message",e.getMessage());
         return returnMap;
     }
 
+    @ExceptionHandler(value = { RuntimeException.class })
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Map<String,String> runtimeException(RuntimeException e) {
+        return getErrorForm(e);
+        /*Map<String,String> returnMap = new HashMap<>();
+        returnMap.put("error",e.toString());
+        returnMap.put("message",e.getMessage());
+        return returnMap;*/
+    }
+
     @ExceptionHandler(value = { TestException.class })
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public Map<String,String> testException(TestException e) {
-        Map<String,String> returnMap = new HashMap<>();
+        return getErrorForm(e);
+        /*Map<String,String> returnMap = new HashMap<>();
         returnMap.put("error",e.toString());
         returnMap.put("message",e.getMessage());
-        return returnMap;
+        return returnMap;*/
+    }
+
+    @ExceptionHandler(value = { MemberException.class })
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Map<String, String> memberException(MemberException e) {
+        return getErrorForm(e);
+        /*Map<String,String> returnMap = new HashMap<>();
+        returnMap.put("error",e.toString());
+        returnMap.put("message",e.getMessage());
+        return returnMap;*/
     }
 }

--- a/src/main/java/com/uad2/application/exception/MemberException.java
+++ b/src/main/java/com/uad2/application/exception/MemberException.java
@@ -1,0 +1,12 @@
+package com.uad2.application.exception;
+/*
+ * @USER JungHyun
+ * @DATE 2019-09-22
+ * @DESCRIPTION
+ */
+
+public class MemberException extends RuntimeException{
+    public MemberException(String msg){
+        super(msg);
+    }
+}

--- a/src/main/java/com/uad2/application/member/controller/MemberController.java
+++ b/src/main/java/com/uad2/application/member/controller/MemberController.java
@@ -76,6 +76,11 @@ public class MemberController {
     public ResponseEntity checkPwd(@RequestBody MemberDto.Request requestMember) {
         Member member = memberRepository.findById(requestMember.getId());
 
+        // check member exist
+        if (member == null) {
+            throw new MemberException("Member is not exist");
+        }
+
         // check password equals
         if (!member.getPwd().equals(EncryptUtil.encryptMD5(requestMember.getPwd()))) {
             throw new MemberException("Password not matched");

--- a/src/main/java/com/uad2/application/member/controller/MemberController.java
+++ b/src/main/java/com/uad2/application/member/controller/MemberController.java
@@ -1,10 +1,12 @@
 package com.uad2.application.member.controller;
 
+import com.uad2.application.exception.MemberException;
 import com.uad2.application.member.MemberValidator;
 import com.uad2.application.member.dto.MemberDto;
 import com.uad2.application.member.entity.Member;
 import com.uad2.application.member.repository.MemberRepository;
 import com.uad2.application.member.service.MemberService;
+import com.uad2.application.utils.EncryptUtil;
 import com.uad2.application.utils.MemberResponseUtil;
 import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
@@ -69,6 +71,25 @@ public class MemberController {
         } else {
             return ResponseEntity.status(202).build();
         }
+    }
+
+    /**
+     * 비밀번호 체크 - 프로필 수정 검증용
+     */
+    @PostMapping(value = "/api/member/checkPwd", produces = MediaTypes.HAL_JSON_UTF8_VALUE)
+    public ResponseEntity checkPwd(@RequestBody MemberDto.Request requestMember, Errors errors) throws Exception {
+        if (errors.hasErrors()) {
+            return ResponseEntity.badRequest().body(errors);
+        }
+
+        Member member = memberRepository.findById(requestMember.getId());
+
+        // check password equals
+        if (!member.getPwd().equals(EncryptUtil.encryptMD5(requestMember.getPwd()))) {
+            throw new MemberException("Password not matched");
+        }
+
+        return ResponseEntity.ok().build();
     }
 }
 /*


### PR DESCRIPTION
utils=>encryptUtil 의 encrypt 기능을 이용하여 체크 요청한 비밀번호 암호화 후 db 에 저장된 암호화되어 저장된 비밀번호와 비교
ExceptionAdvice 에서 폼 공통사용하고있어 공용폼 추가.

** 추가사항 **
1. return getErrorForm(e); 밑에 주석 제거 => 완료

2. if (errors.hasErrors()) {
return ResponseEntity.badRequest().body(errors);
}
error기능 이용 안할거기 때문에 삭제 (createMember메소드 validator 참고)
=> 완료

3. member가 null로 올 경우?? -> member =! null 체크 추가 필요
=> 널체크 추가