### PR TITLE
로깅 환경 설정

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,11 +1,16 @@
+# logging profile 설정 console-logging, file-logging
+spring.profiles.include=console-logging, file-logging
+
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=ENC(lIpWt+CX9teBANDkremrvaHbZTFU4Qg1AJakFPi3U4Ta/XWtdjW5kSj5MeC3lF+hNHyrxpTJDTS/arhhYELnYLEwdUc9cyNhfcSJ0oSkjYubEof4PAkbkoNH2sHVvg7tITNdC70Vt7E2qY1t6nl9wqFOuEkZffHVZRhvVSsBuPk=)
 spring.datasource.username=ENC(MLGKKVMSMxd5/s5w2cSF1J1ltjPY9CNBy6wYpd5Ad7Y=)
 spring.datasource.password=ENC(I/07kkE5oXNuS0+xgcu5iwpu0zFgCW77+SUUwcwsgL042VZNN11eqQ==)
 
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-spring.jpa.properties.hibernate.show_sql=true
-logging.level.org.hibernate.type.descriptor.sql=trace
+spring.jpa.properties.hibernate.show_sql=false
+spring.jpa.properties.hibernate.generate_statistics=true
+spring.jpa.properties.hibernate.format_sql=true
+#logging.level.org.hibernate.type.descriptor.sql=trace
 
 spring.jackson.deserialization.fail-on-unknown-properties=true
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,38 +1,165 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <!-- 변수 지정 -->
-    <property name="LOG_DIR" value="/logs" />
-    <property name="LOG_PATH_NAME" value="${LOG_DIR}/data.log" />
+    <property name="LOG_DIR" value="logs"/>
+    <property name="ALL_LOG_DIR" value="${LOG_DIR}/all"/>
+    <property name="DOMAIN_LOG_DIR" value="${LOG_DIR}/domain"/>
+    <property name="ATTENDANCE_LOG_DIR" value="${DOMAIN_LOG_DIR}/attendance"/>
+    <property name="CALCULATION_LOG_DIR" value="${DOMAIN_LOG_DIR}/calculation"/>
+    <property name="MATCHING_LOG_DIR" value="${DOMAIN_LOG_DIR}/matching"/>
+    <property name="MEMBER_LOG_DIR" value="${DOMAIN_LOG_DIR}/member"/>
+    <property name="NOTICE_LOG_DIR" value="${DOMAIN_LOG_DIR}/notice"/>
 
-    <!-- Send debug messages to System.out -->
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
+    <!-- 콘솔 출력 -->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!-- By default, encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %magenta([%thread]) %clr(%-5level) %logger{36} --- %clr(%msg){cyan} %n
+            </pattern>
         </encoder>
     </appender>
 
-    <!-- Send debug message to file -->
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/spring-boot-logging.log</file>
+    <!-- 전체 로그 파일 저장 -->
+    <appender name="ALL_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${ALL_LOG_DIR}/spring-boot-log.log</file>
 
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} --- %msg %n</pattern>
         </encoder>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>logs/spring-boot-logging.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
-
-            <!-- each file should be at most 10MB, keep 30 days worth of history -->
-            <maxHistory>30</maxHistory>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>10MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${ALL_LOG_DIR}/spring-boot-log.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>  <!-- 하나의 로그 파일 최대 크기 -->
+            <maxHistory>30</maxHistory> <!-- 아카이브 된 파일의 최대 저장일. 해당일 이후 자동 삭제 -->
+            <totalSizeCap>1GB</totalSizeCap>  <!-- 아카이브 된 모든 파일의 최대 크기 -->
         </rollingPolicy>
     </appender>
 
-    <root level="DEBUG">
-        <appender-ref ref="STDOUT" />
-        <appender-ref ref="FILE" />
-    </root>
+    <!-- attendance 도메인 로그 파일 저장 -->
+    <appender name="ATTENDANCE_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${ATTENDANCE_LOG_DIR}/spring-boot-log.log</file>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} --- %msg %n</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${ATTENDANCE_LOG_DIR}/spring-boot-log.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <!-- calculation 도메인 로그 파일 저장-->
+    <appender name="CALCULATION_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${CALCULATION_LOG_DIR}/spring-boot-log.log</file>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} --- %msg %n</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${CALCULATION_LOG_DIR}/spring-boot-log.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <!-- matching 도메인 로그 파일 저장-->
+    <appender name="MATCHING_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${MATCHING_LOG_DIR}/spring-boot-log.log</file>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} --- %msg %n</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${MATCHING_LOG_DIR}/spring-boot-log.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <!-- member 도메인 로그 파일 저장-->
+    <appender name="MEMBER_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${MEMBER_LOG_DIR}/spring-boot-log.log</file>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} --- %msg %n</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${MEMBER_LOG_DIR}/spring-boot-log.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <!-- notice 도메인 로그 파일 저장-->
+    <appender name="NOTICE_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${NOTICE_LOG_DIR}/spring-boot-log.log</file>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} --- %msg %n</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${NOTICE_LOG_DIR}/spring-boot-log.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <!-- 콘솔 로깅(주로 개발 환경에서 사용) -->
+    <springProfile name="console-logging">
+        <root level="DEBUG">    <!-- 루트 패키지 포함정, 하위 모든 패키지 로그 수준 DEBUG -->
+            <appender-ref ref="STDOUT"/>
+        </root>
+
+        <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">     <!-- SQL 로그 -->
+            <appender-ref ref="STDOUT"/>
+        </logger>
+        <logger name="org.hibernate.tool.hbm2ddl" level="DEBUG" additivity="false">    <!-- DDL 로그 -->
+            <appender-ref ref="STDOUT"/>
+        </logger>
+        <logger name="org.hibernate.type" level="TRACE" additivity="false">    <!-- 파라미터 결과 로그 -->
+            <appender-ref ref="STDOUT"/>
+        </logger>
+        <logger name="org.hibernate.stat" level="DEBUG" additivity="false">    <!-- 결과 통계 로그 -->
+            <appender-ref ref="STDOUT"/>
+        </logger>
+        <logger name="org.hibernate.type.BasicTypeRegistry" level="WARN" additivity="false">   <!-- 불필요한 로그 수준 WARN으로 생략-->
+            <appender-ref ref="STDOUT"/>
+        </logger>
+    </springProfile>
+
+    <!-- 파일 저장용 로깅(주로 운영 환경에서 사용) -->
+    <springProfile name="file-logging">
+        <root level="INFO">
+            <appender-ref ref="ALL_FILE"/>
+        </root>
+
+        <logger name="com.uad2.application.attendance" level="INFO" additivity="false">
+            <appender-ref ref="ATTENDANCE_FILE"/>
+        </logger>
+        <logger name="com.uad2.application.calculation" level="INFO" additivity="false">
+            <appender-ref ref="CALCULATION_FILE"/>
+        </logger>
+        <logger name="com.uad2.application.matching" level="INFO" additivity="false">
+            <appender-ref ref="MATCHING_FILE"/>
+        </logger>
+        <logger name="com.uad2.application.member" level="INFO" additivity="false">
+            <appender-ref ref="MEMBER_FILE"/>
+        </logger>
+        <logger name="com.uad2.application.notice" level="INFO" additivity="false">
+            <appender-ref ref="NOTICE_FILE"/>
+        </logger>
+    </springProfile>
+
 </configuration>


### PR DESCRIPTION
## Logback을 사용한 로깅 설정
- '프로젝트 루트/logs/' 디렉토리 하위에 로그 파일 저장.
- 도메인별 로그 파일 관리
- `콘솔 로깅`과 `파일 로깅` 분리하여, 개발/운영 환경에 맞게 전략 수립 가능하도록 함.

### 콘솔 로깅
- 컬러 반영
> ![image](https://user-images.githubusercontent.com/47711143/67630004-824e6e00-f8c3-11e9-8149-4a34fa5d89cf.png)
>
> | **시간** | **쓰레드** | **로그 수준** | **패키지** | **로그 메시지** |
> | ----------|-----------|-----------|-----------|-----------|
> | 2019-10-27 13:55:08.220 | [main] | INFO | o.s.b.w.e.tomcat.TomcatWebServer | Tomcat started on port(s): 8080 (http) with context path |

### 파일 로깅
```
├── logs
│   ├── all
│   │   └── spring-boot-log.log
│   └── domain
│       ├── attendance
│       │   └── spring-boot-log.log
│       ├── calculation
│       │   └── spring-boot-log.log
│       ├── matching
│       │   └── spring-boot-log.log
│       ├── member
│       │   └── spring-boot-log.log
│       └── notice
│           └── spring-boot-log.log

```
>- all 디렉토리
>   - 도메인을 제외한 모든 패키지에 대한 로깅 저장
>   - 로그 파일 크기 제한 — 100MB
>   - 파일 유지 기간 (한번 생성되고 이후 자동 삭제) — 30일
>   - 전체 파일 크기 제한 — 1GB
>- domain 디렉토리
>   - 도메인별로 로그파일 저장하기 위해 따로 두었다.
>   - 로그 파일 크기 제한 — 50MB
>   - 파일 유지 기간 (한번 생성되고 이후 자동 삭제) — 30일
>   - 전체 파일 크기 제한 — 500MB (도메인 폴더별 제한)
#### => `디렉토리 분류 및 파일 유지 제한 조건은 임의로 설정한 것이기 때문에, 추후 협의하여 변경 필요.`

### application.properties 설정
> ```
> spring.profiles.include=console-logging, file-logging
> ```
> - 콘솔 로깅과 파일 로깅을 분리하였기 때문에, 개발/운영 서버에서 선택적으로 로깅 전략을 수립할 수 있다.
> - 현재는 콘솔 로깅, 파일 로깅 모두 되도록 설정해놨음.

### 로깅 테스트
>- 로그를 찍고자 하는 곳 (ex, controller, service...)
> ```java
> Logger logger = LoggerFactory.getLogger(패키지를 포함한 특정 클래스.class);
>
> 메소드() {
>     logger.error("error 로그 테스트");
>     logger.warn("warn 로그 테스트");
>     logger.info("info 로그 테스트");
>     logger.debug("debug 로그 테스트");
>     logger.trace("trace 로그 테스트");
> }
> ```
>- 해당 도메인의 로그 파일에 잘 저장되었는지 확인